### PR TITLE
Handle $vms not being an object

### DIFF
--- a/resources/views/instance/index.blade.php
+++ b/resources/views/instance/index.blade.php
@@ -2,7 +2,13 @@
 
 @section('content')
     <div>
-        @if(count($vms) > 0)
+        @if(is_object($vms) !== true || property_exists($vms, "cserrorcode"))
+            @if(property_exists($vms, "errortext"))
+                Internal Error: {{ $vms->errortext }}
+            @else
+                Internal Error: Can't retrieve instances
+            @endif
+        @elseif(count($vms) > 0)
             <table class="table">
                 <thead>
                 <tr>


### PR DESCRIPTION
This appears to fix `Trying to get property of non-object (View: /var/www/stratostack-portal/resources/views/instance/index.blade.php)` errors