### PR TITLE
Only check for errortext property if $vms is an object

### DIFF
--- a/resources/views/instance/index.blade.php
+++ b/resources/views/instance/index.blade.php
@@ -2,12 +2,10 @@
 
 @section('content')
     <div>
-        @if(is_object($vms) !== true || property_exists($vms, "cserrorcode"))
-            @if(property_exists($vms, "errortext"))
-                Internal Error: {{ $vms->errortext }}
-            @else
-                Internal Error: Can't retrieve instances
-            @endif
+        @if(is_object($vms) === true && property_exists($vms, "errortext"))
+            Internal Error: {{ $vms->errortext }}
+        @elseif(is_object($vms) !== true && is_array($vms) !== true)
+            Internal Error: Can't retrieve instances
         @elseif(count($vms) > 0)
             <table class="table">
                 <thead>


### PR DESCRIPTION
property_exists() requires first parameter to be an object so we should check that first