### PR TITLE
Remove legacy providers from compile config

### DIFF
--- a/config/compile.php
+++ b/config/compile.php
@@ -16,8 +16,6 @@ return [
     'files' => [
 
         realpath(__DIR__.'/../app/Providers/AppServiceProvider.php'),
-        realpath(__DIR__.'/../app/Providers/BusServiceProvider.php'),
-        realpath(__DIR__.'/../app/Providers/ConfigServiceProvider.php'),
         realpath(__DIR__.'/../app/Providers/EventServiceProvider.php'),
         realpath(__DIR__.'/../app/Providers/RouteServiceProvider.php'),
 


### PR DESCRIPTION
Fixes `php_strip_whitespace(/var/www/stratostack-portal): failed to open stream: Success `

https://github.com/laravel/docs/blob/5.3/upgrade.md#compiled-classes